### PR TITLE
Only use existing file name if it has an extension

### DIFF
--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -127,6 +127,22 @@ describe('getFontFilename', () => {
         expect(functions.getFontFilename(urlObject)).toBe(stubUrlMd5);
     });
 
+    test('URL object\s `pathname` contains no extension', () => {
+        const stubUrl = 'https://example.com/font';
+        const stubUrlMd5 = crypto.createHash('md5')
+            .update(stubUrl)
+            .digest()
+            .toString('hex');
+
+        const urlObject: any = {
+            protocol: 'https',
+            hostname: 'example.com',
+            pathname: 'font',
+        };
+
+        expect(functions.getFontFilename(urlObject)).toBe(stubUrlMd5);
+    });
+
     test('works as expected', () => {
         const urlObject: any = {
             pathname: 'folder1/folder2/font.file.woff2',

--- a/src/font-grabber/functions.ts
+++ b/src/font-grabber/functions.ts
@@ -60,11 +60,15 @@ export function isFontFaceSrcContainsRemoteFontUri(cssValue: string): boolean {
  * @param fontUriObject 
  */
 export function getFontFilename(fontUriObject: url.UrlWithStringQuery): string {
-    if (!fontUriObject.pathname) {
-        return md5(url.format(fontUriObject));
+    if (fontUriObject.pathname) {
+        const baseName = path.basename(fontUriObject.pathname);
+
+        if (baseName?.indexOf('.') !== -1) {
+            return baseName;
+        }
     }
 
-    return path.basename(fontUriObject.pathname);
+    return md5(url.format(fontUriObject));
 }
 
 /**


### PR DESCRIPTION
Resolves #10 in a way that requires no configuration.

The md5 will be used in place of the path's basename, if that doesn't contain a file extension. This is determined by whether or not a dot is present.