### PR TITLE
Determine downloaded filenames based on configurable pattern.

### DIFF
--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -6,6 +6,7 @@ export interface PluginOptions {
     cssDest?: string,
     fontDir?: string,
     mkdir?: boolean,
+    filePattern?: string;
 };
 
 export interface PluginSettings {
@@ -13,6 +14,7 @@ export interface PluginSettings {
     cssDestinationDirectoryPath: string | undefined,
     fontDirectoryPath: string | undefined,
     autoCreateDirectory: boolean,
+    filePattern: string;
 };
 
 export interface RemoteFont {

--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -137,6 +137,14 @@ describe('getFontFilename', () => {
         expect(functions.getFontFilename(urlObject, '[name][ext]')).toBe('font.file.woff2');
     });
 
+    test('file has no extension', () => {
+        const urlObject: any = {
+            pathname: 'folder1/folder2/font',
+        };
+
+        expect(functions.getFontFilename(urlObject, '[name][ext]')).toBe('font');
+    });
+
     test('uses fixed extension', () => {
         const urlObject: any = {
             pathname: 'folder1/folder2/font.file.woff2',

--- a/src/font-grabber/functions.ts
+++ b/src/font-grabber/functions.ts
@@ -74,8 +74,10 @@ export function getFontFilename(
     return filePattern
         .replace(/\[path\]/gi, () => sanitize(pathname))
         .replace(/\[query\]/gi, () => sanitize(fontUriObject.query ?? ''))
-        .replace(/\[name\]/gi, () => path.basename(pathname)
-            .slice(0, -path.extname(pathname).length))
+        .replace(/\[name\]/gi, () => {
+            const baseName = path.basename(pathname);
+            return baseName.substr(0, baseName.length - path.extname(pathname).length)
+        })
         .replace(/\[ext\]/gi, () => path.extname(pathname))
         .replace(/\[hash\]/gi, () => md5(url.format(fontUriObject)));
 }


### PR DESCRIPTION
Resolves #10 by means of an additional configuration option to allow control of downloaded file names.

Happy to add to the readme if you prefer this approach to the other one.