### PR TITLE
When no font filename is found, determine extension automatically

### DIFF
--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -21,20 +21,23 @@ export interface RemoteFont {
 }
 
 export interface Job {
+    declaration: postcss.Declaration,
     remoteFont: RemoteFont,
     css: {
         sourcePath: string,
         destinationDirectoryPath: string,
     },
     font: {
-        path: string,
-        filename: string,
+        destinationDirectoryPath: string,
+        destinationRelativePath: string,
     },
 }
 
 export interface JobResult {
     job: Job,
     download: {
+        path: string,
+        fileName: string,
         size: number,
     },
 }

--- a/src/font-grabber/downloader/contract.ts
+++ b/src/font-grabber/downloader/contract.ts
@@ -9,13 +9,15 @@ export interface FileSystem {
 export type HttpGet = typeof http.get;
 
 export interface FileInfo {
+    fileName: string,
+    filePath: string,
     size: number,
 }
 
 export interface Downloader {
     download(
         urlObject: url.UrlWithStringQuery,
-        filePath: string,
+        destinationDirectoryPath: string,
         timeout?: number
     ): Promise<FileInfo>;
 }

--- a/src/font-grabber/downloader/index.spec.ts
+++ b/src/font-grabber/downloader/index.spec.ts
@@ -33,17 +33,20 @@ describe('Downloader shloud download fonts correctly', () => {
         const fakeHttpGet = Helper.makeGet(fakeResponse);
         const fakeHttpsGet = Helper.makeGet(fakeResponse);
 
-        const urlObject = url.parse('http://example.com');
-        const filePath = '/var/project/public/fonts/font1.woff';
+        const fileName = 'font1.woff';
+        const urlObject = url.parse('http://example.com/' + fileName);
+        const downloadDir = '/var/project/public/fonts/';
 
         const downloader = new Downloader(fakeFs, fakeHttpGet, fakeHttpsGet);
-        const fileInfo = downloader.download(urlObject, filePath);
+        const fileInfo = downloader.download(urlObject, downloadDir);
 
         expect(await fileInfo).toEqual({
+            fileName,
+            filePath: downloadDir + fileName,
             size: responseSize,
         });
 
-        expect(createWriteStream).toBeCalledWith(filePath);
+        expect(createWriteStream).toBeCalledWith(downloadDir + fileName);
         expect(fakeResponse.pipe.mock.calls[0][0]).toBe(fakeWritableStream);
         expect(fakeResponse.pipe.mock.calls[0][1]).toEqual({ end: true });
         expect(fakeResponse.on.mock.calls[0][0]).toBe('data');

--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -108,7 +108,9 @@ describe('getFontFilename', () => {
             hostname: 'example.com',
         };
 
-        expect(functions.getFontFilename(urlObject)).toBe(stubUrlMd5);
+        const contentType = 'font/woff2';
+
+        expect(functions.getFontFilename(urlObject, contentType)).toBe(stubUrlMd5 + '.woff2');
     });
 
     test('URL object\'s `pathname` is an empty string', () => {
@@ -124,10 +126,12 @@ describe('getFontFilename', () => {
             pathname: '',
         };
 
-        expect(functions.getFontFilename(urlObject)).toBe(stubUrlMd5);
+        const contentType = 'font/woff2';
+
+        expect(functions.getFontFilename(urlObject, contentType)).toBe(stubUrlMd5 + '.woff2');
     });
 
-    test('URL object\s `pathname` contains no extension', () => {
+    test('URL object\'s `pathname` contains no extension', () => {
         const stubUrl = 'https://example.com/font';
         const stubUrlMd5 = crypto.createHash('md5')
             .update(stubUrl)
@@ -140,15 +144,29 @@ describe('getFontFilename', () => {
             pathname: 'font',
         };
 
-        expect(functions.getFontFilename(urlObject)).toBe(stubUrlMd5);
+        const contentType = 'font/truetype';
+
+        expect(functions.getFontFilename(urlObject, contentType)).toBe(stubUrlMd5 + '.ttf');
     });
 
-    test('works as expected', () => {
+    test('pathname overrides contentType', () => {
         const urlObject: any = {
             pathname: 'folder1/folder2/font.file.woff2',
         };
 
-        expect(functions.getFontFilename(urlObject)).toBe('font.file.woff2');
+        const contentType = 'font/woff';
+
+        expect(functions.getFontFilename(urlObject, contentType)).toBe('font.file.woff2');
+    });
+
+    test('contentType isn\'t required', () => {
+        const urlObject: any = {
+            pathname: 'folder1/folder2/font.file.woff',
+        };
+
+        const contentType = undefined;
+
+        expect(functions.getFontFilename(urlObject, contentType)).toBe('font.file.woff');
     });
 
 });

--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -330,9 +330,10 @@ describe('processDeclaration', () => {
                     sourcePath: cssSourceFilePath,
                     destinationDirectoryPath: cssDestinationDirectoryPath,
                 },
+                declaration,
                 font: {
-                    path: `${downloadDirectoryPath}font1.woff2`,
-                    filename: 'font1.woff2',
+                    destinationDirectoryPath: downloadDirectoryPath,
+                    destinationRelativePath: "../fonts"
                 },
             },
             {
@@ -344,9 +345,10 @@ describe('processDeclaration', () => {
                     sourcePath: cssSourceFilePath,
                     destinationDirectoryPath: cssDestinationDirectoryPath,
                 },
+                declaration,
                 font: {
-                    path: `${downloadDirectoryPath}font2.woff`,
-                    filename: 'font2.woff',
+                    destinationDirectoryPath: downloadDirectoryPath,
+                    destinationRelativePath: "../fonts"
                 },
             },
         ];

--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -354,7 +354,6 @@ describe('processDeclaration', () => {
         ];
 
         expect(jobs).toEqual(expect.arrayContaining(expected));
-        expect(declaration.value).toEqual(' url(../fonts/font1.woff2) format(woff2), url(../fonts/font2.woff)');
     });
 
 });

--- a/src/font-grabber/index.spec.ts
+++ b/src/font-grabber/index.spec.ts
@@ -36,7 +36,9 @@ describe('makeTransformer', () => {
                 destinationDirectoryPath: values.cssSourceDirectoryPath,
                 destinationRelativePath: '.',
             },
-            declaration: {} as any as postcss.Declaration,
+            declaration: {
+                value: ' url(https://example.com/folder/font1.woff2) format(woff2), url(https://example.com/folder/font2.woff)',
+            } as postcss.Declaration,
         };
         const postcssNode: any = {
             value: ` url(${values.remoteFontUrl}) format(${values.fontFormat}) `,
@@ -147,6 +149,9 @@ describe('makeTransformer', () => {
                             destinationDirectoryPath: values.cssSourceDirectoryPath,
                             destinationRelativePath: '.',
                         },
+                        declaration: {
+                            value: ' url(../fonts/font1.woff2) format(woff2), url(../fonts/font2.woff)'
+                        }
                     },
                 },
             ],

--- a/src/font-grabber/index.spec.ts
+++ b/src/font-grabber/index.spec.ts
@@ -1,3 +1,4 @@
+import postcss from 'postcss';
 import url from 'url';
 
 jest.mock('./functions');
@@ -32,9 +33,10 @@ describe('makeTransformer', () => {
                 destinationDirectoryPath: values.cssDestinationDirectoryPath,
             },
             font: {
-                path: values.localFontPath,
-                filename: values.fontFilename,
+                destinationDirectoryPath: values.cssSourceDirectoryPath,
+                destinationRelativePath: '.',
             },
+            declaration: {} as any as postcss.Declaration,
         };
         const postcssNode: any = {
             value: ` url(${values.remoteFontUrl}) format(${values.fontFormat}) `,
@@ -84,6 +86,8 @@ describe('makeTransformer', () => {
                 job,
                 download: {
                     size: values.fontFileSize,
+                    fileName: values.fontFilename,
+                    path: values.localFontPath,
                 },
             });
         });
@@ -127,6 +131,8 @@ describe('makeTransformer', () => {
                 {
                     download: {
                         size: values.fontFileSize,
+                        fileName: values.fontFilename,
+                        path: values.localFontPath,
                     },
                     job: {
                         remoteFont: {
@@ -138,8 +144,8 @@ describe('makeTransformer', () => {
                             destinationDirectoryPath: values.cssDestinationDirectoryPath,
                         },
                         font: {
-                            path: values.localFontPath,
-                            filename: values.fontFilename,
+                            destinationDirectoryPath: values.cssSourceDirectoryPath,
+                            destinationRelativePath: '.',
                         },
                     },
                 },


### PR DESCRIPTION
When a font is downloaded from a url that doesn't have a filename for it, the font is saved with a filename that is a hash of its url.

That doesn't work for my (webpack) use case, because I'd like to still be able to give the filename an appropriate file extension in this scenario.

This PR uses the content-type header to decide a filename. I had considered using the filename within the content-disposition header, but google fonts calls them all "font" still (e.g. font.woff2, font.ttf) so that doesn't work with multiple fonts.

This involved more refactoring than I'd hoped, as previously the filename was known before the download started. Annoyingly, the declaration now needs to be passed around with the job, so it can be updated once the file name has been determined.