### PR TITLE
Add support for postcss 8.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "jest": "^26.4.2",
     "sinon": "^9.0.3",
     "ts-jest": "^26.4.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.0.3",
+    "postcss": "^8.0.0"
   },
-  "dependencies": {
-    "postcss": ">=6 <=8"
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   }
 }

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,4 +1,4 @@
-import postcss from 'postcss';
+import { ChildNode } from 'postcss';
 import * as url from 'url';
 
 export interface PluginOptions {
@@ -45,6 +45,6 @@ export interface Meta {
 
 export type DoneCallback = (meta: Meta) => void;
 
-export type PostcssChildNodeProcessor = (node: postcss.ChildNode, index: number) => any;
+export type PostcssChildNodeProcessor = (node: ChildNode, index: number) => any;
 
 export type Dictionary<U> = { [key: string]: U };

--- a/src/font-grabber/functions.ts
+++ b/src/font-grabber/functions.ts
@@ -1,4 +1,4 @@
-import postcss from 'postcss';
+import { ChildNode, Declaration } from 'postcss';
 import path from 'path';
 import url from 'url';
 
@@ -30,10 +30,10 @@ export function parseOptions(options: PluginOptions): PluginSettings {
 
 /**
  * 
- * @param {postcss.ChildNode} node
+ * @param {ChildNode} node
  * @returns {boolean}
  */
-export function isRemoteFontFaceDeclaration(node: postcss.ChildNode): boolean {
+export function isRemoteFontFaceDeclaration(node: ChildNode): boolean {
     if (node.type !== 'decl') {
         return false;
     }
@@ -130,7 +130,7 @@ export function reduceSrcsToFontInfos(fontInfos: RemoteFont[], src: string): Rem
  * @param downloadDirectoryPath 
  */
 export function processDeclaration(
-    declaration: postcss.Declaration,
+    declaration: Declaration,
     cssSourceFilePath: string,
     cssDestinationDirectoryPath: string,
     downloadDirectoryPath: string

--- a/src/font-grabber/index.spec.ts
+++ b/src/font-grabber/index.spec.ts
@@ -55,10 +55,12 @@ describe('makeTransformer', () => {
                 callback(rule);
             },
         };
-        const postcssResult: any = {
-            opts: {
-                to: values.postcssOptsTo,
-            },
+        const postcssResult = {
+            result: {
+                opts: {
+                    to: values.postcssOptsTo,
+                },
+            }
         };
 
         /**
@@ -109,7 +111,7 @@ describe('makeTransformer', () => {
             });
         });
 
-        await transformer(postcssRoot, postcssResult);
+        await (transformer.Once as Function)(postcssRoot, postcssResult);
 
         /**
          * assertions

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * @author         AaronJan <https://github.com/AaronJan/postcss-font-grabber>
  */
 
-import postcss from 'postcss';
+import { PluginCreator } from 'postcss';
 import { PluginOptions } from './contracts';
 import { FontGrabber } from './font-grabber';
 import { parseOptions } from './font-grabber/functions';
@@ -26,7 +26,7 @@ function makeInstance(options: PluginOptions | undefined): FontGrabber {
 /**
  * 
  */
-const plugin = options => {
+const plugin: PluginCreator<PluginOptions> = options => {
     return makeInstance(options).makeTransformer();
 };
 plugin.postcss = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,10 @@ function makeInstance(options: PluginOptions | undefined): FontGrabber {
 /**
  * 
  */
-const plugin = postcss.plugin<PluginOptions>('postcss-font-grabber', options => {
+const plugin = options => {
     return makeInstance(options).makeTransformer();
-});
+};
+plugin.postcss = true
 
 export {
     makeInstance,


### PR DESCRIPTION
Steps 1 and 2 (of 5) of the migration to PostCSS 8.x.x are done.
Migration guide: https://evilmartians.com/chronicles/postcss-8-plugin-migration