### PR TITLE
bug: Handle the case where format is `embedded-opentype`

### DIFF
--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -202,6 +202,15 @@ describe('parseSrcString', () => {
     });
   });
 
+  test('short format', () => {
+    const src = 'url(https://example.com/folder/font) format(eot)';
+
+    expect(functions.parseSrcString(src)).toEqual({
+      urlObject: url.parse('https://example.com/folder/font'),
+      format: 'eot',
+    });
+  });
+
   test('long format', () => {
     const src =
       'url(https://example.com/folder/font) format(embedded-opentype)';

--- a/src/font-grabber/functions.test.ts
+++ b/src/font-grabber/functions.test.ts
@@ -201,6 +201,16 @@ describe('parseSrcString', () => {
       format: undefined,
     });
   });
+
+  test('long format', () => {
+    const src =
+      'url(https://example.com/folder/font) format(embedded-opentype)';
+
+    expect(functions.parseSrcString(src)).toEqual({
+      urlObject: url.parse('https://example.com/folder/font'),
+      format: 'embedded-opentype',
+    });
+  });
 });
 
 describe('getNewDeclarationValue', () => {

--- a/src/font-grabber/functions.ts
+++ b/src/font-grabber/functions.ts
@@ -68,7 +68,7 @@ export function guessFormatFromUrl(
 }
 
 export function parseSrcString(src: string): undefined | ParsedSrc {
-  const result = /^url\s*\(\s*[\'\"]?(https?:[^\)]*?)[\'\"]?\s*\)(\s+format\([\'\"]?([a-zA-Z0-9]+)[\'\"]?\))?/.exec(
+  const result = /^url\s*\(\s*[\'\"]?(https?:[^\)]*?)[\'\"]?\s*\)(\s+format\([\'\"]?([\-a-zA-Z0-9]+)[\'\"]?\))?/.exec(
     src,
   );
   if (result === null) {


### PR DESCRIPTION
Seems like some developers prefer writing `embedded-opentype` as opposed to `eot`. This changes the regex pattern to match that string too.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Strings like the following do not contain font format information:
```css
url("https://cloud.webtype.com/webtype/ff2/2/5c217aa9-a850-4b71-98c8-da6a84490961?ec_token=8f7c4c4...c9c#iefix") format("embedded-opentype")
```

## What is the new behavior?
Strings like the following do contain 'embedded-opentype' as format information:
```css
url("https://cloud.webtype.com/webtype/ff2/2/5c217aa9-a850-4b71-98c8-da6a84490961?ec_token=8f7c4c4...c9c#iefix") format("embedded-opentype")
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information